### PR TITLE
Add AutoResearchExam citation

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,50 @@
+cff-version: 1.2.0
+message: If you use AutoResearchExam in your research, please cite this work.
+title: AutoResearchExam
+authors:
+- given-names: Anirudha
+  family-names: Ramesh
+- given-names: Siddartha
+  family-names: Devic
+- given-names: Shivank
+  family-names: Garg
+- given-names: Advait
+  family-names: Parulekar
+- given-names: Drish
+  family-names: Mahnot
+- given-names: Shreyas
+  family-names: Pimpalgaonkar
+- given-names: Vishnu
+  family-names: Suresh
+- given-names: Alex
+  family-names: Dimakis
+- given-names: Maheswaran
+  family-names: Sathiamoorthy
+date-released: '2026-09-09'
+url: https://benchmarks.bespokelabs.ai/autoresearchexam/
+repository-code: https://github.com/bespokelabsai/AutoResearchExam
+preferred-citation:
+  type: generic
+  title: AutoResearchExam
+  authors:
+  - given-names: Anirudha
+    family-names: Ramesh
+  - given-names: Siddartha
+    family-names: Devic
+  - given-names: Shivank
+    family-names: Garg
+  - given-names: Advait
+    family-names: Parulekar
+  - given-names: Drish
+    family-names: Mahnot
+  - given-names: Shreyas
+    family-names: Pimpalgaonkar
+  - given-names: Vishnu
+    family-names: Suresh
+  - given-names: Alex
+    family-names: Dimakis
+  - given-names: Maheswaran
+    family-names: Sathiamoorthy
+  year: 2026
+  month: 9
+  url: https://benchmarks.bespokelabs.ai/autoresearchexam/

--- a/README.md
+++ b/README.md
@@ -101,3 +101,26 @@ pie showData
 - [Sparse dictionary coding](./sae-sparse-dict-nmse-frontier)
 
 </details>
+
+## Citation
+
+If you use AutoResearchExam in your research, please cite:
+
+```bibtex
+@misc{ramesh2026autoresearchexam,
+  author = {Ramesh, Anirudha and
+            Devic, Siddartha and
+            Garg, Shivank and
+            Parulekar, Advait and
+            Mahnot, Drish and
+            Pimpalgaonkar, Shreyas and
+            Suresh, Vishnu and
+            Dimakis, Alex and
+            Sathiamoorthy, Maheswaran},
+  title = {{AutoResearchExam}},
+  year = {2026},
+  month = sep,
+  url = {https://benchmarks.bespokelabs.ai/autoresearchexam/},
+  note = {Published September 9, 2026}
+}
+```

--- a/citation.bib
+++ b/citation.bib
@@ -1,0 +1,16 @@
+@misc{ramesh2026autoresearchexam,
+  author = {Ramesh, Anirudha and
+            Devic, Siddartha and
+            Garg, Shivank and
+            Parulekar, Advait and
+            Mahnot, Drish and
+            Pimpalgaonkar, Shreyas and
+            Suresh, Vishnu and
+            Dimakis, Alex and
+            Sathiamoorthy, Maheswaran},
+  title = {{AutoResearchExam}},
+  year = {2026},
+  month = sep,
+  url = {https://benchmarks.bespokelabs.ai/autoresearchexam/},
+  note = {Published September 9, 2026}
+}


### PR DESCRIPTION
Adds a README citation, downloadable BibTeX, and CITATION.cff for GitHub citation support. Uses the agreed author order, September 9, 2026 publication date, and canonical benchmark URL.

Validation: CITATION.cff validated against the CFF 1.2.0 schema; citation metadata checked for consistency; git diff --check passed.